### PR TITLE
Fixed the multiple new tab start and stop scraping bugs

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -20,12 +20,6 @@
     "48": "icons/icon48.png",
     "128": "icons/icon128.png"
   },
-  "content_scripts": [
-    {
-      "matches": ["<all_urls>"],
-      "js": ["content.js"]
-    }
-  ],
   "web_accessible_resources": [{
     "resources": ["content.js"],
     "matches": ["<all_urls>"]

--- a/popup.html
+++ b/popup.html
@@ -26,8 +26,7 @@
 </head>
 <body>
   <h1>Web Scraper</h1>
-  <button id="start-scraping">Start Scraping</button>
-  <button id="stop-scraping">Stop Scraping</button>
+
   <select id="export-format">
     <option value="json">Export JSON</option>
     <option value="csv">Export CSV</option>

--- a/popup.html
+++ b/popup.html
@@ -26,7 +26,8 @@
 </head>
 <body>
   <h1>Web Scraper</h1>
-
+  <button id="start-scraping">Start Scraping</button>
+  <button id="stop-scraping">Stop Scraping</button>
   <select id="export-format">
     <option value="json">Export JSON</option>
     <option value="csv">Export CSV</option>

--- a/popup.js
+++ b/popup.js
@@ -1,20 +1,20 @@
+document.addEventListener('DOMContentLoaded', () => {
+
 document.getElementById('start-scraping').addEventListener('click', async () => {
   // Clear existing data
-  chrome.storage.local.set({ scrapedData: [] });
+  chrome.storage.local.set({ scrapedData: [], scraperActive: true });
 
   let [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
   chrome.scripting.executeScript({
     target: { tabId: tab.id },
     files: ['content.js']
   });
-});
+}); 
 
 document.getElementById('stop-scraping').addEventListener('click', async () => {
+  chrome.storage.local.set({ scraperActive: false });
   let [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
-  chrome.scripting.executeScript({
-    target: { tabId: tab.id },
-    func: stopScraping
-  });
+  chrome.tabs.sendMessage(tab.id, { action: 'stopScraping' });
 });
 
 document.getElementById('export-data').addEventListener('click', () => {
@@ -64,3 +64,5 @@ function exportData(format) {
     URL.revokeObjectURL(url);
   });
 }
+
+});


### PR DESCRIPTION
In manifest.json, removed the content_scripts section, injecting the script manually when needed, in popup.js modified the start scraping event listener, in content.js, modified the script to check if scraping should be active before setting up the event listener, and in popup.js again, wrapped the code in a DOMContentLoaded event listener and modified the stop-scraping event listener, added back the buttons to start and stop scraping.